### PR TITLE
tmbench: Make it more resilient to WSConn breaking

### DIFF
--- a/tm-bench/README.md
+++ b/tm-bench/README.md
@@ -61,7 +61,7 @@ through the number of transactions. If its too slow, the loop stops at one secon
 If its too fast, we wait until the one second mark ends. The transactions per
 second stat is computed based off of what ends up in the block.
 
-Each of the connections is running via a separate goroutine. 
+Each of the connections is handled via two separate goroutines. 
 
 ## Development
 

--- a/tm-bench/main.go
+++ b/tm-bench/main.go
@@ -108,8 +108,12 @@ Examples:
 	endTime := time.Duration(duration) * time.Second
 	select {
 	case <-time.After(endTime):
-		for _, t := range transacters {
+		for i, t := range transacters {
 			t.Stop()
+			numCrashes := countCrashes(t.connStatus)
+			if numCrashes != 0 {
+				fmt.Printf("%d connections crashed on transacter #%d\n", numCrashes, i)
+			}
 		}
 
 		timeStop := time.Now()
@@ -140,6 +144,16 @@ func latestBlockHeight(client tmrpc.Client) int64 {
 		os.Exit(1)
 	}
 	return status.SyncInfo.LatestBlockHeight
+}
+
+func countCrashes(errs []error) int {
+	count := 0
+	for i := 0; i < len(errs); i++ {
+		if errs[i] != nil {
+			count++
+		}
+	}
+	return count
 }
 
 // calculateStatistics calculates the tx / second, and blocks / second based

--- a/tm-bench/main.go
+++ b/tm-bench/main.go
@@ -110,7 +110,7 @@ Examples:
 	case <-time.After(endTime):
 		for i, t := range transacters {
 			t.Stop()
-			numCrashes := countCrashes(t.connStatus)
+			numCrashes := countCrashes(t.connsBroken)
 			if numCrashes != 0 {
 				fmt.Printf("%d connections crashed on transacter #%d\n", numCrashes, i)
 			}
@@ -146,10 +146,10 @@ func latestBlockHeight(client tmrpc.Client) int64 {
 	return status.SyncInfo.LatestBlockHeight
 }
 
-func countCrashes(errs []error) int {
+func countCrashes(crashes []bool) int {
 	count := 0
-	for i := 0; i < len(errs); i++ {
-		if errs[i] != nil {
+	for i := 0; i < len(crashes); i++ {
+		if crashes[i] {
 			count++
 		}
 	}

--- a/tm-bench/transacter.go
+++ b/tm-bench/transacter.go
@@ -34,9 +34,10 @@ type transacter struct {
 	Connections       int
 	BroadcastTxMethod string
 
-	conns   []*websocket.Conn
-	wg      sync.WaitGroup
-	stopped bool
+	conns      []*websocket.Conn
+	connStatus []error
+	wg         sync.WaitGroup
+	stopped    bool
 
 	logger log.Logger
 }
@@ -49,6 +50,7 @@ func newTransacter(target string, connections, rate int, size int, broadcastTxMe
 		Connections:       connections,
 		BroadcastTxMethod: broadcastTxMethod,
 		conns:             make([]*websocket.Conn, connections),
+		connStatus:        make([]error, connections),
 		logger:            log.NewNopLogger(),
 	}
 }
@@ -100,11 +102,15 @@ func (t *transacter) receiveLoop(connIndex int) {
 		_, _, err := c.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-				t.logger.Error("failed to read response", "err", err)
+				t.logger.Error(
+					fmt.Sprintf("failed to read response on conn %d", connIndex),
+					"err",
+					err,
+				)
 			}
 			return
 		}
-		if t.stopped {
+		if t.stopped || t.connStatus[connIndex] != nil {
 			return
 		}
 	}
@@ -169,8 +175,11 @@ func (t *transacter) sendLoop(connIndex int) {
 					Params:  rawParamsJSON,
 				})
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "%v. Try reducing the connections count and increasing the rate.\n", errors.Wrap(err, "txs send failed"))
-					os.Exit(1)
+					err = errors.Wrap(err,
+						fmt.Sprintf("txs send failed on connection #%d", connIndex))
+					t.connStatus[connIndex] = err
+					logger.Error(err.Error())
+					return
 				}
 
 				// Time added here is 7.13 ns/op, not significant enough to worry about
@@ -186,16 +195,21 @@ func (t *transacter) sendLoop(connIndex int) {
 			}
 
 			timeToSend := time.Now().Sub(startTime)
+			logger.Info(fmt.Sprintf("sent %d transactions", numTxSent), "took", timeToSend)
 			if timeToSend < 1*time.Second {
-				time.Sleep(time.Second - timeToSend)
+				sleepTime := time.Second - timeToSend
+				logger.Info(fmt.Sprintf("connection #%d is sleeping for %f seconds", connIndex, sleepTime.Seconds()))
+				time.Sleep(sleepTime)
 			}
 
-			logger.Info(fmt.Sprintf("sent %d transactions", numTxSent), "took", timeToSend)
 		case <-pingsTicker.C:
 			// go-rpc server closes the connection in the absence of pings
 			c.SetWriteDeadline(time.Now().Add(sendTimeout))
 			if err := c.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
-				logger.Error("failed to write ping message", "err", err)
+				err = errors.Wrap(err,
+					fmt.Sprintf("failed to write ping message on conn #%d", connIndex))
+				logger.Error(err.Error())
+				t.connStatus[connIndex] = err
 			}
 		}
 
@@ -205,7 +219,10 @@ func (t *transacter) sendLoop(connIndex int) {
 			c.SetWriteDeadline(time.Now().Add(sendTimeout))
 			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 			if err != nil {
-				logger.Error("failed to write close message", "err", err)
+				err = errors.Wrap(err,
+					fmt.Sprintf("failed to write close message on conn #%d", connIndex))
+				logger.Error(err.Error())
+				t.connStatus[connIndex] = err
 			}
 
 			return

--- a/tm-bench/transacter.go
+++ b/tm-bench/transacter.go
@@ -198,7 +198,7 @@ func (t *transacter) sendLoop(connIndex int) {
 			logger.Info(fmt.Sprintf("sent %d transactions", numTxSent), "took", timeToSend)
 			if timeToSend < 1*time.Second {
 				sleepTime := time.Second - timeToSend
-				logger.Info(fmt.Sprintf("connection #%d is sleeping for %f seconds", connIndex, sleepTime.Seconds()))
+				logger.Debug(fmt.Sprintf("connection #%d is sleeping for %f seconds", connIndex, sleepTime.Seconds()))
 				time.Sleep(sleepTime)
 			}
 


### PR DESCRIPTION
This commit changes the behavior of a broken connection from calling
os.Exit, to instead killing that connection. This also improves
the debug logging, by specifying connection index within errors.

ref #105, should check off "Make it more resilient to WSConn breaking", unless we want the intended behavior to be retrying to create a new connection once one breaks.